### PR TITLE
Update gradle-wrapper.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ allprojects {
     apply plugin: 'jacoco'
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     jacoco {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
updated distributionUrl to gradle-7.2-bin.zip because I was having similar issues as described here ( https://github.com/gradle/gradle/issues/15538 ) when doing simple things like ./gradlew run