### PR TITLE
Gradle Updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ allprojects {
     apply plugin: 'jacoco'
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     jacoco {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updated distributionUrl in gradle-wrapper.properties to gradle-7.2-bin.zip because I was having similar issues as described here ( gradle/gradle#15538 ) when doing simple things like ./gradlew run

Updated build.gradle to use mavenCentral repo (jcenter repo is deprecated and will be removed in Gradle 8)