### PR TITLE
Change JDK to amazoncorretto:17

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: openjdk:15
+image: amazoncorretto:17
 
 stages: 
   - test


### PR DESCRIPTION
openJDK ist deprecated and does not get any updates.
Sonar does no longer work with code that is compiled with Java 15
This fixes these issues